### PR TITLE
fix: no suffix on value for --vram

### DIFF
--- a/Days/Linux/VAGRANTFILE
+++ b/Days/Linux/VAGRANTFILE
@@ -3,6 +3,6 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |v|
    v.memory  = 8096
    v.cpus    = 4
-   v.customize ["modifyvm", :id, "--vram", "128mb"]
+   v.customize ["modifyvm", :id, "--vram", "128"]
 end
 end


### PR DESCRIPTION
Value for --vram is assumed to be in mb already, so only value is required. [--vram <vramsize in MB>]
Followed the https://www.virtualbox.org/manual/ch08.html#vboxmanage-cmd-overview