### PR TITLE
Fix day11

### DIFF
--- a/Days/Go/day11_example2.go
+++ b/Days/Go/day11_example2.go
@@ -6,6 +6,6 @@ func main() {
 	var challenge = "#90DaysOfDevOps"
 	const daystotal = 90
 
-	fmt.Println("Welcome to", challenge)
+	fmt.Println("Welcome to", challenge, "")
 	fmt.Println("This is a", daystotal, "challenge")
 }

--- a/Days/day11.md
+++ b/Days/day11.md
@@ -39,7 +39,7 @@ import "fmt"
 
 func main() {
     var challenge = "#90DaysOfDevOps"
-    fmt.Println("Welcome to", challenge "")
+    fmt.Println("Welcome to", challenge, "")
 }
 ```
 You can find the above code snippet in [day11_example1.go](Go/day11_example1.go)
@@ -61,7 +61,7 @@ func main() {
     var challenge = "#90DaysOfDevOps"
     const daystotal = 90
 
-    fmt.Println("Welcome to", challenge)
+    fmt.Println("Welcome to", challenge, "")
     fmt.Println("This is a", daystotal, "challenge")
 }
 ```


### PR DESCRIPTION
fix: day11.md day11_example1 add missing comma.

fix: day11.md day11_example2 add the last empty string parameter for consistency.

fix:  day11_example2.go add the last empty string parameter to match the documented example.