### PR TITLE
Create add-contributors.yml

### DIFF
--- a/.github/workflows/add-contributors.yml
+++ b/.github/workflows/add-contributors.yml
@@ -1,0 +1,24 @@
+name: Add contributors
+on:
+  schedule:
+    - cron:  '0 12 * * *'
+# push:
+#   branches:
+#     - master
+
+jobs:
+  add-contributors:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: BobAnkh/add-contributors@master
+      with:
+        REPO_NAME: 'MichaelCade/90DaysOfDevOps'
+        CONTRIBUTOR: '### Other Contributors'
+        COLUMN_PER_ROW: '6'
+        ACCESS_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        IMG_WIDTH: '100'
+        FONT_SIZE: '14'
+        PATH: '/Contributors.md'
+        COMMIT_MESSAGE: 'docs(Contributors): update contributors'
+        AVATAR_SHAPE: 'round'


### PR DESCRIPTION
This is a GitHub action that runs every day and fetched all the contributors and adds it to `Contributors.md`
We can have a static block above `Other Contributors` according to the chat we had on #255 