### PR TITLE
GitHub actions 1

### DIFF
--- a/.github/workflows/Auto_message_on_creatingissues.yml
+++ b/.github/workflows/Auto_message_on_creatingissues.yml
@@ -1,0 +1,16 @@
+name: Auto message on Creating a Issue.
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create comment for issue
+      if: github.event_name =='issues'
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{tojson(github.event.issue.number)}}
+        body: Hello there!👋, @${{ github.actor }} Welcome to the Solidity-Pathshala! 🚀⚡Thank you and Congratulations🎉 for opening a issue in this project. Please make sure not to start working on this issue, unless you are assigned to it.😄

--- a/.github/workflows/Auto_message_on_pr_merge.yml
+++ b/.github/workflows/Auto_message_on_pr_merge.yml
@@ -1,0 +1,19 @@
+name: Auto message on Pr merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  auto-response:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: derekprior/add-autoresponse@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        respondableId: ${{ github.event.pull_request.node_id }}
+        response: "Thank you @${{ github.event.pull_request.user.login }} for taking out your valuable time in order to contribute to our project. Looking forward for more such amazing contributions :)"
+        author: ${{ github.event.pull_request.user.login }}
+        exemptedAuthors: "Vikash-8090-Yadav"

--- a/.github/workflows/Auto_message_on_pr_open.yml
+++ b/.github/workflows/Auto_message_on_pr_open.yml
@@ -1,0 +1,19 @@
+name: Auto message on PR opened
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  auto-response:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: derekprior/add-autoresponse@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        respondableId: ${{ github.event.pull_request.node_id }}
+        response: "Our team will soon review your PR. Thanks @${{ github.event.pull_request.user.login }} :)"
+        author: ${{ github.event.pull_request.user.login }}
+        exemptedAuthors: "Vikash-8090-Yadav"


### PR DESCRIPTION
Solved issue #415 

In this repository, there is only one action available for first-time contributors to date.
I added the GitHub Action for the user who opens the issue, pr or merges the pr.


Advantage - 

1. This will display the message to all the user who opens or closes the issue and pr. It is not limited to first-time contributors only. 
2. You don't have to greet after merging Pr. 
3. This saves time as well as increases audience engagement. 
