### PR TITLE
fix: replace broken ContainIQ links with Prometheus official docs

### DIFF
--- a/2022/Days/day78.md
+++ b/2022/Days/day78.md
@@ -93,6 +93,6 @@ I want to come back to Prometheus but for now, I think we need to think about Lo
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 See you on [Day 79](day79.md)

--- a/2022/Days/day79.md
+++ b/2022/Days/day79.md
@@ -72,7 +72,7 @@ Log Management is a key aspect of the overall observability of your applications
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/Days/day80.md
+++ b/2022/Days/day80.md
@@ -97,7 +97,7 @@ I was reading this article from MetricFire [Prometheus vs. ELK](https://www.metr
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/Days/day81.md
+++ b/2022/Days/day81.md
@@ -156,7 +156,7 @@ I also found this great medium article covering more about [Fluent Bit](https://
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/Days/day82.md
+++ b/2022/Days/day82.md
@@ -103,7 +103,7 @@ I am not going to get into APM here but you can find out more on the [Elastic si
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/Days/day83.md
+++ b/2022/Days/day83.md
@@ -144,7 +144,7 @@ Next up we are going to be taking a look into data management and how DevOps pri
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/es/Days/day79.md
+++ b/2022/es/Days/day79.md
@@ -62,7 +62,7 @@ La gestión de registros es un aspecto clave de la observabilidad general de tus
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/es/Days/day80.md
+++ b/2022/es/Days/day80.md
@@ -87,7 +87,7 @@ Estaba leyendo este artículo de MetricFire [Prometheus vs. ELK](https://www.met
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/es/Days/day81.md
+++ b/2022/es/Days/day81.md
@@ -147,7 +147,7 @@ También encontré este excelente artículo de Medium que cubre más sobre [Flue
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/es/Days/day82.md
+++ b/2022/es/Days/day82.md
@@ -93,7 +93,7 @@ No profundizaré en APM aquí, pero puedes obtener más información en la [web 
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/ko/Days/day80.md
+++ b/2022/ko/Days/day80.md
@@ -97,7 +97,7 @@ Beats가 추가되면서 ELK Stack은 이제 Elastic Stack이라고도 불립니
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/ko/Days/day83.md
+++ b/2022/ko/Days/day83.md
@@ -144,7 +144,7 @@ Kubernetes API 서버 대시보드를 선택하고 새로 추가된 Prometheus-1
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/pl/day78.md
+++ b/2022/pl/day78.md
@@ -91,6 +91,6 @@ I want to come back to Prometheus but for now I think we need to think about Log
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 See you on [Day 79](day79.md)

--- a/2022/pl/day79.md
+++ b/2022/pl/day79.md
@@ -72,7 +72,7 @@ Log Management is a key aspect of the overall observability of your applications
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/pl/day80.md
+++ b/2022/pl/day80.md
@@ -99,7 +99,7 @@ I was reading this article from MetricFire [Prometheus vs. ELK](https://www.metr
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/pl/day81.md
+++ b/2022/pl/day81.md
@@ -156,7 +156,7 @@ I also found this really great medium article covering more about [Fluent Bit](h
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/pl/day82.md
+++ b/2022/pl/day82.md
@@ -102,7 +102,7 @@ I am not going to get into APM here but you can find out more on the [Elastic si
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/pl/day83.md
+++ b/2022/pl/day83.md
@@ -141,7 +141,7 @@ Next up we are going to be taking a look into data management and how DevOps pri
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/vi/Days/day78.md
+++ b/2022/vi/Days/day78.md
@@ -92,6 +92,6 @@ Tôi muốn nhắc lại về Prometheus nhưng bây giờ, tôi nghĩ chúng ta
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 
 Hẹn gặp lại vào [ngày 79](day79.md)

--- a/2022/vi/Days/day81.md
+++ b/2022/vi/Days/day81.md
@@ -157,7 +157,7 @@ Tôi cũng tìm thấy bài viết này trên medium giải thích thêm về [F
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg)
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/zh_cn/Days/day80.md
+++ b/2022/zh_cn/Days/day80.md
@@ -99,7 +99,7 @@ I was reading this article from MetricFire [Prometheus vs. ELK](https://www.metr
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/2022/zh_cn/Days/day81.md
+++ b/2022/zh_cn/Days/day81.md
@@ -156,7 +156,7 @@ I also found this really great medium article covering more about [Fluent Bit](h
 - [Top 5 - DevOps Monitoring Tools](https://www.youtube.com/watch?v=4t71iv_9t_4)
 - [How Prometheus Monitoring works](https://www.youtube.com/watch?v=h4Sl21AKiDg) 
 - [Introduction to Prometheus monitoring](https://www.youtube.com/watch?v=5o37CGlNLr8)
-- [Promql cheat sheet with examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples)
+- [Promql cheat sheet with examples](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 - [Log Management for DevOps | Manage application, server, and cloud logs with Site24x7](https://www.youtube.com/watch?v=J0csO_Shsj0)
 - [Log Management what DevOps need to know](https://devops.com/log-management-what-devops-teams-need-to-know/)
 - [What is ELK Stack?](https://www.youtube.com/watch?v=4X0WLg05ASw)

--- a/Resources.md
+++ b/Resources.md
@@ -732,7 +732,7 @@ Day-78
 - [https://www.youtube.com/watch?v=4t71iv_9t_4](https://www.youtube.com/watch?v=4t71iv_9t_4) Top 5 - DevOps Monitoring Tools
 - [https://www.youtube.com/watch?v=h4Sl21AKiDg](https://www.youtube.com/watch?v=h4Sl21AKiDg) How Prometheus Monitoring works
 - [https://www.youtube.com/watch?v=5o37CGlNLr8](https://www.youtube.com/watch?v=5o37CGlNLr8) Introduction to Prometheus monitoring
-- [https://www.containiq.com/post/promql-cheat-sheet-with-examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples) Promql cheat sheet with examples
+- [https://prometheus.io/docs/prometheus/latest/querying/basics/](https://prometheus.io/docs/prometheus/latest/querying/basics/) Promql cheat sheet with examples
 
 Day-79
 
@@ -742,7 +742,7 @@ Day-79
 - [https://www.youtube.com/watch?v=4t71iv_9t_4](https://www.youtube.com/watch?v=4t71iv_9t_4) Top 5 - DevOps Monitoring Tools
 - [https://www.youtube.com/watch?v=h4Sl21AKiDg](https://www.youtube.com/watch?v=h4Sl21AKiDg) How Prometheus Monitoring works
 - [https://www.youtube.com/watch?v=5o37CGlNLr8](https://www.youtube.com/watch?v=5o37CGlNLr8) Introduction to Prometheus monitoring
-- [https://www.containiq.com/post/promql-cheat-sheet-with-examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples) Promql cheat sheet with examples
+- [https://prometheus.io/docs/prometheus/latest/querying/basics/](https://prometheus.io/docs/prometheus/latest/querying/basics/) Promql cheat sheet with examples
 - [https://www.youtube.com/watch?v=J0csO_Shsj0](https://www.youtube.com/watch?v=J0csO_Shsj0) Log Management for DevOps | Manage application, server, and cloud logs with Site24x7
 - [https://devops.com/log-management-what-devops-teams-need-to-know/](https://devops.com/log-management-what-devops-teams-need-to-know/) Log Management what DevOps need to know
 - [https://www.youtube.com/watch?v=4X0WLg05ASw](https://www.youtube.com/watch?v=4X0WLg05ASw) What is ELK Stack?
@@ -757,7 +757,7 @@ Day-80
 - [https://www.youtube.com/watch?v=4t71iv_9t_4](https://www.youtube.com/watch?v=4t71iv_9t_4) Top 5 - DevOps Monitoring Tools
 - [https://www.youtube.com/watch?v=h4Sl21AKiDg](https://www.youtube.com/watch?v=h4Sl21AKiDg) How Prometheus Monitoring works
 - [https://www.youtube.com/watch?v=5o37CGlNLr8](https://www.youtube.com/watch?v=5o37CGlNLr8) Introduction to Prometheus monitoring
-- [https://www.containiq.com/post/promql-cheat-sheet-with-examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples) Promql cheat sheet with examples
+- [https://prometheus.io/docs/prometheus/latest/querying/basics/](https://prometheus.io/docs/prometheus/latest/querying/basics/) Promql cheat sheet with examples
 - [https://www.youtube.com/watch?v=J0csO_Shsj0](https://www.youtube.com/watch?v=J0csO_Shsj0) Log Management for DevOps | Manage application, server, and cloud logs with Site24x7
 - [https://devops.com/log-management-what-devops-teams-need-to-know/](https://devops.com/log-management-what-devops-teams-need-to-know/) Log Management what DevOps need to know
 - [https://www.youtube.com/watch?v=4X0WLg05ASw](https://www.youtube.com/watch?v=4X0WLg05ASw) What is ELK Stack?
@@ -772,7 +772,7 @@ Day-81
 - [https://www.youtube.com/watch?v=4t71iv_9t_4](https://www.youtube.com/watch?v=4t71iv_9t_4) Top 5 - DevOps Monitoring Tools
 - [https://www.youtube.com/watch?v=h4Sl21AKiDg](https://www.youtube.com/watch?v=h4Sl21AKiDg) How Prometheus Monitoring works
 - [https://www.youtube.com/watch?v=5o37CGlNLr8](https://www.youtube.com/watch?v=5o37CGlNLr8) Introduction to Prometheus monitoring
-- [https://www.containiq.com/post/promql-cheat-sheet-with-examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples) Promql cheat sheet with examples
+- [https://prometheus.io/docs/prometheus/latest/querying/basics/](https://prometheus.io/docs/prometheus/latest/querying/basics/) Promql cheat sheet with examples
 - [https://www.youtube.com/watch?v=J0csO_Shsj0](https://www.youtube.com/watch?v=J0csO_Shsj0) Log Management for DevOps | Manage application, server, and cloud logs with Site24x7
 - [https://devops.com/log-management-what-devops-teams-need-to-know/](https://devops.com/log-management-what-devops-teams-need-to-know/) Log Management what DevOps need to know
 - [https://www.youtube.com/watch?v=4X0WLg05ASw](https://www.youtube.com/watch?v=4X0WLg05ASw) What is ELK Stack?
@@ -788,7 +788,7 @@ Day-82
 - [https://www.youtube.com/watch?v=4t71iv_9t_4](https://www.youtube.com/watch?v=4t71iv_9t_4) Top 5 - DevOps Monitoring Tools
 - [https://www.youtube.com/watch?v=h4Sl21AKiDg](https://www.youtube.com/watch?v=h4Sl21AKiDg) How Prometheus Monitoring works
 - [https://www.youtube.com/watch?v=5o37CGlNLr8](https://www.youtube.com/watch?v=5o37CGlNLr8) Introduction to Prometheus monitoring
-- [https://www.containiq.com/post/promql-cheat-sheet-with-examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples) Promql cheat sheet with examples
+- [https://prometheus.io/docs/prometheus/latest/querying/basics/](https://prometheus.io/docs/prometheus/latest/querying/basics/) Promql cheat sheet with examples
 - [https://www.youtube.com/watch?v=J0csO_Shsj0](https://www.youtube.com/watch?v=J0csO_Shsj0) Log Management for DevOps | Manage application, server, and cloud logs with Site24x7
 - [https://devops.com/log-management-what-devops-teams-need-to-know/](https://devops.com/log-management-what-devops-teams-need-to-know/) Log Management what DevOps need to know
 - [https://www.youtube.com/watch?v=4X0WLg05ASw](https://www.youtube.com/watch?v=4X0WLg05ASw) What is ELK Stack?
@@ -803,7 +803,7 @@ Day-83
 - [https://www.youtube.com/watch?v=4t71iv_9t_4](https://www.youtube.com/watch?v=4t71iv_9t_4) Top 5 - DevOps Monitoring Tools
 - [https://www.youtube.com/watch?v=h4Sl21AKiDg](https://www.youtube.com/watch?v=h4Sl21AKiDg) How Prometheus Monitoring works
 - [https://www.youtube.com/watch?v=5o37CGlNLr8](https://www.youtube.com/watch?v=5o37CGlNLr8) Introduction to Prometheus monitoring
-- [https://www.containiq.com/post/promql-cheat-sheet-with-examples](https://www.containiq.com/post/promql-cheat-sheet-with-examples) Promql cheat sheet with examples
+- [https://prometheus.io/docs/prometheus/latest/querying/basics/](https://prometheus.io/docs/prometheus/latest/querying/basics/) Promql cheat sheet with examples
 - [https://www.youtube.com/watch?v=J0csO_Shsj0](https://www.youtube.com/watch?v=J0csO_Shsj0) Log Management for DevOps | Manage application, server, and cloud logs with Site24x7
 - [https://devops.com/log-management-what-devops-teams-need-to-know/](https://devops.com/log-management-what-devops-teams-need-to-know/) Log Management what DevOps need to know
 - [https://www.youtube.com/watch?v=4X0WLg05ASw](https://www.youtube.com/watch?v=4X0WLg05ASw) What is ELK Stack?


### PR DESCRIPTION
## Summary

The ContainIQ PromQL cheat sheet links (`containiq.com/post/promql-cheat-sheet-with-examples`) are broken. ContainIQ shut down and the domain is no longer active. All requests time out.

This PR replaces these broken links with the official Prometheus PromQL documentation (`prometheus.io/docs/prometheus/latest/querying/basics/`), which is the canonical and actively maintained source for PromQL syntax and examples.

## Changes

- **Resources.md**: Replaced 6 broken ContainIQ PromQL links
- **2022/Days/day78-83.md**: Replaced broken links in all 6 English day files
- **Translated versions** (pl, es, vi, ko, zh_cn): Fixed the same broken links across 16 translation files

**23 files fixed total.**

## Verification

```
$ curl -s -o /dev/null -w "%{http_code}" --max-time 5 https://www.containiq.com/post/promql-cheat-sheet-with-examples
000  # connection timeout - site is dead

$ curl -s -o /dev/null -w "%{http_code}" https://prometheus.io/docs/prometheus/latest/querying/basics/
200  # working
```